### PR TITLE
Some small changes to the readme for macOS Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install -r requirements.txt
 pip install --global-option=build_ext --global-option="-I/usr/local/Cellar/portaudio/19.6.0/include" --global-option="-L/usr/local/Cellar/portaudio/19.6.0/lib" pyaudio
 
 
-python ap2-receiver.py -m myap2
+python ap2-receiver.py -m myap2 --netiface=en0
 ```
 
 * the AirPlay 2 receiver is announced as **myap2**.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ To run the receiver please use Python 3 and do the following:
 * Run the following commands
 
 ```zsh
+brew install python3
 brew install portaudio
-virtualenv proto
+virtualenv -p /usr/local/bin/python3 proto
 source proto/bin/activate
 pip install -r requirements.txt
 pip install --global-option=build_ext --global-option="-I/usr/local/Cellar/portaudio/19.6.0/include" --global-option="-L/usr/local/Cellar/portaudio/19.6.0/lib" pyaudio


### PR DESCRIPTION
I found that python3 is not installed by default. Installing it with brew puts it in parallel with python 2.7, so I added instructions for how to use virtualenv with python3. Also the `--netiface` argument seems to be required so I added that too.