### PR TITLE
Docker image, pyalsaaudio, audio device etc.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,29 @@
+name: Build and Push Docker Image
+ 
+on:
+  push:
+    branches: master
+ 
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./docker/Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm64
+          push: true
+          tags: charlesomer/airplay:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,116 @@
+events.bin
+proto
+Features.xlsx
+airplay-env
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,vscode,macos,windows,linux,c
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,vscode,macos,windows,linux,c
+
+### C ###
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
 
 # C extensions
-*.so
 
 # Distribution / packaging
 .Python
@@ -50,6 +156,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+pytestdebug.log
 
 # Translations
 *.mo
@@ -70,6 +177,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+doc/_build/
 
 # PyBuilder
 target/
@@ -109,6 +217,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pythonenv*
 
 # Spyder project settings
 .spyderproject
@@ -127,3 +236,45 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# profiling data
+.prof
+
+### vscode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/python,vscode,macos,windows,linux,c

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ services:
       # - AP2HOSTNAME=Airplay2Device
       # - AP2IFACE=eth0
       # - AUDIO_DEVICE=default # For use with alsaaudio.
-      # - USE_PORTAUDIO=true # If this is set to true, volume management is also disabled
+      # - DISABLE_PORTAUDIO=true
       # - NO_VOLUME_MANAGEMENT=true
     devices:
       - "/dev/snd"

--- a/README.md
+++ b/README.md
@@ -27,42 +27,64 @@ Next steps:
  - FairPlay v2 Support
 ---
 
-## Raspberry Pi 4
+## Pre-Built Docker Image
+This image is built directly from `master` so may break. Tested with Raspberry Pi.
+
+https://hub.docker.com/r/charlesomer/airplay
+
+Example Docker Compose
+```zsh
+version: "3.8"
+services:
+  airplay:
+    image: charlesomer/airplay:latest
+    restart: always
+    network_mode: host
+    environment: # All variables are optional.
+      # - AP2HOSTNAME=Airplay2Device
+      # - AP2IFACE=eth0
+      # - AUDIO_DEVICE=default # For use with alsaaudio.
+      # - USE_PORTAUDIO=true # If this is set to true, volume management is also disabled
+      # - NO_VOLUME_MANAGEMENT=true
+    devices:
+      - "/dev/snd"
+```
+
+## Raspberry Pi
 
 Install docker and then build the image:
 
 ```zsh
-docker build -f docker/Dockerfile -t invano/ap2-receiver .
+docker build -f docker/Dockerfile -t USERNAME/airplay .
 ```
 
 To run the receiver:
 
 ```zsh
-docker run -it --rm --device /dev/snd --net host invano/ap2-receiver
+docker run -it --rm --device /dev/snd --net host USERNAME/airplay
 ```
 
-Default network device is wlan0, you can change this with AP2IFACE env variable:
+## macOS
 
+_macOS has shown issues when playing audio, if anyone is able to take a look at this to confirm/fix that would be great._
+
+Currently `portaudio` is required for MacOS. It can be installed via homebrew:
 ```zsh
-docker run -it --rm --device /dev/snd --env AP2IFACE=eth0 --net host invano/ap2-receiver
-```
-
-## macOS Catalina
-
-To run the receiver please use Python 3 and do the following:
-
-* Run the following commands
-
-```zsh
-brew install python3
 brew install portaudio
-virtualenv -p /usr/local/bin/python3 proto
-source proto/bin/activate
-pip install -r requirements.txt
-pip install --global-option=build_ext --global-option="-I/usr/local/Cellar/portaudio/19.6.0/include" --global-option="-L/usr/local/Cellar/portaudio/19.6.0/lib" pyaudio
+```
+Then, you may be able to use the docker image although this is untested. Add the `--use-portaudio` option. Alternatively, clone the repo and run via python virtualenv.
 
+```zsh
+pip3 install virtualenv
+virtualenv -p /usr/local/bin/python3 airplay-env
+source airplay-env/bin/activate
+pip3 install -r requirements.txt
+
+# The following line may not be required.
+# pip3 install --global-option=build_ext --global-option="-I/usr/local/Cellar/portaudio/19.6.0/include" --global-option="-L/usr/local/Cellar/portaudio/19.6.0/lib" pyaudio
 
 python ap2-receiver.py -m myap2 --netiface=en0
+# Allow incoming connections.
 ```
 
 ## Windows

--- a/ap2-receiver.py
+++ b/ap2-receiver.py
@@ -68,7 +68,7 @@ HTTP_CT_IMAGE = "image/jpeg"
 HTTP_CT_DMAP = "application/x-dmap-tagged"
 
 AUDIO_DEVICE = "default"
-USE_PORTAUDIO = False
+USE_PORTAUDIO = True
 
 def setup_global_structs(args):
     global sonos_one_info
@@ -715,7 +715,7 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--netiface", required=True, help="Network interface to bind to")
     parser.add_argument("-nv", "--no-volume-management", required=False, help="Disable volume management", action='store_true')
     parser.add_argument("-d", "--audio-device", required=False, help="Specify output device (string).", default='default') 
-    parser.add_argument("-po", "--use-portaudio", required=False, help="Use port audio (useful for Windows and MacOS).", default=False)
+    parser.add_argument("-dpo", "--disable-portaudio", required=False, help="Disable portaudio.", default=False)
     parser.add_argument("-f", "--features", required=False, help="Features")
 
     args = parser.parse_args()
@@ -726,7 +726,7 @@ if __name__ == "__main__":
         DISABLE_VM = args.no_volume_management
 
         AUDIO_DEVICE = args.audio_device
-        USE_PORTAUDIO = args.use_portaudio
+        USE_PORTAUDIO = not args.disable_portaudio
         if args.features:
             try:
                 FEATURES = int(args.features, 16)

--- a/ap2/connections/stream.py
+++ b/ap2/connections/stream.py
@@ -8,7 +8,7 @@ class Stream:
     REALTIME = 96
     BUFFERED = 103
 
-    def __init__(self, stream):
+    def __init__(self, stream, audio_device, use_portaudio):
         self.audio_format = stream["audioFormat"]
         self.compression = stream["ct"]
         self.session_key = stream["shk"]
@@ -20,9 +20,9 @@ class Stream:
             self.server_control = stream["controlPort"]
             self.latency_min = stream["latencyMin"]
             self.latency_max = stream["latencyMax"]
-            self.data_port, self.data_proc, audio_connection = AudioRealtime.spawn(self.session_key, self.audio_format)
+            self.data_port, self.data_proc, audio_connection = AudioRealtime.spawn(self.session_key, self.audio_format, audio_device, use_portaudio)
         elif self.type == Stream.BUFFERED:
-            self.data_port, self.data_proc, self.audio_connection = AudioBuffered.spawn(self.session_key, self.audio_format)
+            self.data_port, self.data_proc, self.audio_connection = AudioBuffered.spawn(self.session_key, self.audio_format, audio_device, use_portaudio)
 
     def teardown(self):
         self.data_proc.terminate()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:stable-slim
 
 RUN apt-get update -yy && \
     apt-get install -yy \
@@ -13,22 +13,25 @@ RUN apt-get update -yy && \
         python3-pyaudio \
         libffi-dev \
         alsa-utils \
-	libavformat-dev \
-	libavcodec-dev \
-	libavdevice-dev \
-	libavutil-dev \
-	libavfilter-dev \
-	libswscale-dev \
-	libswresample-dev
+        libavformat-dev \
+        libavcodec-dev \
+        libavdevice-dev \
+        libavutil-dev \
+        libavfilter-dev \
+        libswscale-dev \
+        libswresample-dev \
+        libasound2-dev
 
-COPY ap2-receiver.py /airplay2/ap2-receiver.py
-COPY ap2 /airplay2/ap2
-COPY requirements.txt /airplay2/requirements.txt
+WORKDIR /airplay2
 
-RUN pip3 install -r /airplay2/requirements.txt
+COPY ./ap2-receiver.py ./ap2-receiver.py
+COPY ./ap2 ./ap2
 
-COPY docker/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
-COPY docker/start.sh /
+COPY ./requirements.txt ./requirements.txt
+RUN pip3 install -r ./requirements.txt
+
+COPY ./docker/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
+COPY ./docker/start.sh /
 
 RUN chmod +x /start.sh
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,0 @@
-Docker env for Raspberry Pi testing.
-
-*Tested on RPi 4*

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -6,6 +6,18 @@ fi
 if [ -z "${AP2IFACE}" ]; then
     export AP2IFACE='wlan0'
 fi
+if [ -z "${AUDIO_DEVICE}" ]; then
+    export AUDIO_DEVICE='default'
+fi
+NO_VOLUME_MANAGEMENT_FLAG=""
+if [ "${NO_VOLUME_MANAGEMENT}" = "true" ]; then
+    NO_VOLUME_MANAGEMENT_FLAG='--no-volume-management'
+fi
+USE_PORTAUDIO_FLAG=""
+if [ "${USE_PORTAUDIO}" = "true" ]; then
+    USE_PORTAUDIO_FLAG='--use-portaudio'
+    NO_VOLUME_MANAGEMENT_FLAG='--no-volume-management'
+fi
 
 # Swap hostname in the avahi config
 sed "s/\(host-name=\).*/\1${AP2HOSTNAME}/g" -i /etc/avahi/avahi-daemon.conf
@@ -16,4 +28,4 @@ sed "s/\(host-name=\).*/\1${AP2HOSTNAME}/g" -i /etc/avahi/avahi-daemon.conf
 
 # Start AirPlay 2 service
 cd /airplay2
-exec python3 ap2-receiver.py -m ${AP2HOSTNAME} -n ${AP2IFACE} --no-volume-management 
+exec python3 ap2-receiver.py -m ${AP2HOSTNAME} -n ${AP2IFACE} --audio-device ${AUDIO_DEVICE} ${NO_VOLUME_MANAGEMENT_FLAG} ${USE_PORTAUDIO_FLAG}

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -13,10 +13,9 @@ NO_VOLUME_MANAGEMENT_FLAG=""
 if [ "${NO_VOLUME_MANAGEMENT}" = "true" ]; then
     NO_VOLUME_MANAGEMENT_FLAG='--no-volume-management'
 fi
-USE_PORTAUDIO_FLAG=""
-if [ "${USE_PORTAUDIO}" = "true" ]; then
-    USE_PORTAUDIO_FLAG='--use-portaudio'
-    NO_VOLUME_MANAGEMENT_FLAG='--no-volume-management'
+DISABLE_PORTAUDIO_FLAG=""
+if [ "${DISABLE_PORTAUDIO}" = "true" ]; then
+    DISABLE_PORTAUDIO_FLAG='--disable-portaudio'
 fi
 
 # Swap hostname in the avahi config
@@ -28,4 +27,4 @@ sed "s/\(host-name=\).*/\1${AP2HOSTNAME}/g" -i /etc/avahi/avahi-daemon.conf
 
 # Start AirPlay 2 service
 cd /airplay2
-exec python3 ap2-receiver.py -m ${AP2HOSTNAME} -n ${AP2IFACE} --audio-device ${AUDIO_DEVICE} ${NO_VOLUME_MANAGEMENT_FLAG} ${USE_PORTAUDIO_FLAG}
+exec python3 ap2-receiver.py -m ${AP2HOSTNAME} -n ${AP2IFACE} --audio-device ${AUDIO_DEVICE} ${NO_VOLUME_MANAGEMENT_FLAG} ${DISABLE_PORTAUDIO_FLAG}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ cryptography
 requests
 av
 numpy
+pyaudio
+pyalsaaudio; sys_platform == 'linux'


### PR DESCRIPTION
Let me know what you think of this PR. Obviously things like the README and GitHub actions would need to be modified but I wasn't sure what they would need to be changed to at the moment.

Now supports `pyalsaaudio` for devices such as Raspberry Pi instead of PortAudio which wasn't working before. This means volume control now works as well. PortAudio still exists and can be enabled.

Automated docker builds, it takes about 2 hours to build upon a push to master but requires docker hub credentials etc.