### PR TITLE
fix: set a default value when can't retrieve

### DIFF
--- a/ap2/utils.py
+++ b/ap2/utils.py
@@ -81,7 +81,7 @@ def get_volume():
     if subsys == "Darwin":
         try:
             pct = int(subprocess.check_output(["osascript", "-e", "output volume of (get volume settings)"]).rstrip())
-        except:
+        except ValueError:
             pct = 0
         vol = interpolate(pct, 0, 100, -30, 0)
     elif subsys == "Linux":

--- a/ap2/utils.py
+++ b/ap2/utils.py
@@ -79,7 +79,10 @@ def get_pycaw_volume_session():
 def get_volume():
     subsys = platform.system()
     if subsys == "Darwin":
-        pct = int(subprocess.check_output(["osascript", "-e", "output volume of (get volume settings)"]).rstrip())
+        try:
+            pct = int(subprocess.check_output(["osascript", "-e", "output volume of (get volume settings)"]).rstrip())
+        except:
+            pct = 0
         vol = interpolate(pct, 0, 100, -30, 0)
     elif subsys == "Linux":
         line_pct = subprocess.check_output(["amixer", "get", "PCM"]).splitlines()[-1]


### PR DESCRIPTION
When running 

```
osascript -e "output volume of (get volume settings)"

```
with an external soundcard connected I get: "missing value" and the receiver doesn't start. This tries to solve this.