### PR TITLE
Fix iOS 15 Issue & Add PTP Master Toggle

### DIFF
--- a/ap2-receiver.py
+++ b/ap2-receiver.py
@@ -225,16 +225,16 @@ def setup_global_structs(args):
     }
 
     sonos_one_setup = {
-        'eventPort': 0,  # AP2 receiver event server
-        'timingPort': 0,
-        'timingPeerInfo': {
-            'Addresses':
-            [
-                IPV4,
-                IPV6
-            ],
-            'ID': IPV4}
+        'eventPort': 0  # AP2 receiver event server
     }
+    if not DISABLE_PTP_MASTER:
+        sonos_one_setup['timingPort'] = 0
+        sonos_one_setup['timingPeerInfo'] = {
+            'Addresses': [
+                IPV4, IPV6
+            ],
+            'ID': IPV4
+        }
 
     sonos_one_setup_data = {
         'streams': [
@@ -894,6 +894,8 @@ if __name__ == "__main__":
     parser.add_argument("-m", "--mdns", help="mDNS name to announce", default="myap2")
     parser.add_argument("-n", "--netiface", help="Network interface to bind to. Use the --list-interfaces option to list available interfaces.")
     parser.add_argument("-nv", "--no-volume-management", help="Disable volume management", action='store_true')
+    parser.add_argument("-npm", "--no-ptp-master", help="Stops this receiver from being announced as the PTP Master",
+                        action='store_true')
     mutexgroup.add_argument("-f", "--features", help="Features: a hex representation of Airplay features. Note: mutex with -ft(xxx)")
     mutexgroup.add_argument(
         "-ft", nargs='+', type=int, metavar='F',
@@ -932,6 +934,7 @@ if __name__ == "__main__":
         exit(-1)
 
     DISABLE_VM = args.no_volume_management
+    DISABLE_PTP_MASTER = args.no_ptp_master
     if args.features:
         # Old way. Leave for those who use this way.
         try:

--- a/ap2/pairing/hap.py
+++ b/ap2/pairing/hap.py
@@ -109,6 +109,10 @@ class Hap:
         self.encrypted = False
         self.pair_setup_steps_n = 5
 
+        self.accessory_id = b"00000000-0000-0000-0000-deadbeef0bad"
+        # self.accessory_ltsk = 0
+        # self.accessory_ltpk = 0
+
     def request(self, req):
         req = Tlv8.decode(req)
 
@@ -241,6 +245,9 @@ class Hap:
             format=serialization.PublicFormat.Raw
         )
         self.accessory_shared_key = self.accessory_curve.exchange(x25519.X25519PublicKey.from_public_bytes(client_public))
+
+        self.accessory_ltsk = nacl.signing.SigningKey.generate()
+        self.accessory_ltpk = bytes(self.accessory_ltsk.verify_key)
 
         accessory_info = self.accessory_curve_public + self.accessory_id + client_public
         accessory_signed = self.accessory_ltsk.sign(accessory_info)


### PR DESCRIPTION
This PR adds two things to address two separate issues that can easily be mistaken as one issue.

1. A command-line argument to prevent announcing the receiver as the PTP master, which I have found is not currently working whatsoever.
2. The necessary attributes have been added to the `Hap` object so that music streaming from iOS 15, whilst `Feat.Ft46HkPairing` is enabled, streaming does not fail unexpectedly.

This addresses #29 in its entirety and part of the problem for #38.