### PR TITLE
fixed docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker build -f docker/Dockerfile -t ap2-receiver .
 To run the receiver:
 
 ```zsh
-docker run -it --rm --device /dev/snd --net host ap2-receiver --volume `pwd`/pairings/:/airplay2/pairings/
+docker run -it --rm --device /dev/snd --net host --volume `pwd`/pairings/:/airplay2/pairings/ ap2-receiver
 ```
 
 Default network device is wlan0, you can change this with AP2IFACE env variable:


### PR DESCRIPTION
The name of the docker container needs to be **after** all other arguments in the command. The original command returned this error on my systems.
```
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "--volume": executable file not found in $PATH: unknown.
```