### PR TITLE
Dockerfile best practice: Disable caching to reduce size of docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,13 +19,14 @@ RUN apt-get update -yy && \
 	libavutil-dev \
 	libavfilter-dev \
 	libswscale-dev \
-	libswresample-dev
+	libswresample-dev \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY ap2-receiver.py /airplay2/ap2-receiver.py
 COPY ap2 /airplay2/ap2
 COPY requirements.txt /airplay2/requirements.txt
 
-RUN pip3 install -r /airplay2/requirements.txt
+RUN pip3 install -r /airplay2/requirements.txt --no-cache-dir
 
 COPY docker/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 COPY docker/start.sh /


### PR DESCRIPTION
`apt-get` and `pip` commands cache resources by default, which increases the size of docker containers.

This PR disables caching for both of those tools, with the size difference visible in the code blocks below.

Resources:
 - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 - https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Old stack:

```
>> docker history docker_ap2
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
812d04f6a605   58 minutes ago      CMD ["/start.sh"]                               0B        buildkit.dockerfile.v0
<missing>      58 minutes ago      RUN /bin/sh -c chmod +x /start.sh # buildkit    602B      buildkit.dockerfile.v0
<missing>      58 minutes ago      COPY docker/start.sh / # buildkit               602B      buildkit.dockerfile.v0
<missing>      58 minutes ago      COPY docker/avahi-daemon.conf /etc/avahi/ava…   1.76kB    buildkit.dockerfile.v0
<missing>      58 minutes ago      RUN /bin/sh -c pip3 install -r /airplay2/req…   142MB     buildkit.dockerfile.v0
<missing>      About an hour ago   COPY requirements.txt /airplay2/requirements…   110B      buildkit.dockerfile.v0
<missing>      About an hour ago   COPY ap2 /airplay2/ap2 # buildkit               846kB     buildkit.dockerfile.v0
<missing>      About an hour ago   COPY ap2-receiver.py /airplay2/ap2-receiver.…   58.5kB    buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c apt-get update -yy &&     apt…   745MB     buildkit.dockerfile.v0
<missing>      11 days ago         /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      11 days ago         /bin/sh -c #(nop) ADD file:ec3d90624857dbfae…   108MB
```

New stack:

```
>> docker history docker_ap2
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
b5d0165c5e22   3 minutes ago   CMD ["/start.sh"]                               0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/sh -c chmod +x /start.sh # buildkit    602B      buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY docker/start.sh / # buildkit               602B      buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY docker/avahi-daemon.conf /etc/avahi/ava…   1.76kB    buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN /bin/sh -c pip3 install -r /airplay2/req…   98.9MB    buildkit.dockerfile.v0
<missing>      6 minutes ago   COPY requirements.txt /airplay2/requirements…   110B      buildkit.dockerfile.v0
<missing>      6 minutes ago   COPY ap2 /airplay2/ap2 # buildkit               846kB     buildkit.dockerfile.v0
<missing>      6 minutes ago   COPY ap2-receiver.py /airplay2/ap2-receiver.…   58.5kB    buildkit.dockerfile.v0
<missing>      6 minutes ago   RUN /bin/sh -c apt-get update -yy &&     apt…   728MB     buildkit.dockerfile.v0
<missing>      11 days ago     /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      11 days ago     /bin/sh -c #(nop) ADD file:ec3d90624857dbfae…   108MB
```