### PR TITLE
Dockerfile best practice: COPY source code after pip install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,11 +21,12 @@ RUN apt-get update -yy && \
 	libswscale-dev \
 	libswresample-dev
 
-COPY ap2-receiver.py /airplay2/ap2-receiver.py
-COPY ap2 /airplay2/ap2
 COPY requirements.txt /airplay2/requirements.txt
 
 RUN pip3 install -r /airplay2/requirements.txt
+
+COPY ap2-receiver.py /airplay2/ap2-receiver.py
+COPY ap2 /airplay2/ap2
 
 COPY docker/avahi-daemon.conf /etc/avahi/avahi-daemon.conf
 COPY docker/start.sh /


### PR DESCRIPTION
Due to have docker containers increment container changes in layers, the best practice in the community is to load source code files AFTER installing third party dependencies (i.e. pip install).

In the current config, any time a change is made to ap2-receiver.py or any files in the ap2 directory, docker is prompted to rerun the `pip install` command, which is slow and bandwidth intensive.

With the proposed changes in this PR, after the initial build, `pip install` will only run if the requirements.py has changed.