### PR TITLE
Remove numpy from requirements

### DIFF
--- a/ap2/connections/audio.py
+++ b/ap2/connections/audio.py
@@ -7,7 +7,6 @@ import time
 import logging
 
 import av
-import numpy
 import pyaudio
 from Crypto.Cipher import ChaCha20_Poly1305
 from Crypto.Cipher import AES

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ hkdf
 cryptography
 requests
 av
-numpy


### PR DESCRIPTION
`numpy` is currently unused in the source code. Since numpy is a rather large package to build and bundle, my opinion is that it doesn't make sense to include if it's not in use.

If there's a reason for its presence in the requirements.txt (e.g. for debugging?), perhaps it makes sense to provide a comment in requirements.txt explaining the rationale.

Note: it also looks like `requests` is unused, should we remove that from requirements.txt too?