### PR TITLE
Lock av version to 8.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ hkdf
 # pynacl
 cryptography
 requests
-av
+av==8.1.0


### PR DESCRIPTION
This PR resolves #71.

On my machine (M1 Mac / ARM64), av>=9.0.0 has weird issues where the package is installed in a directory that is not part of the sys.path, resulting in a ModuleNotFound error.

Locking the version to the last version before 9.0.0 appears to resolve the issue.

### Odds and ends

It may also be possible to resolve this issue by removing `--no-cache-dir` in the Dockerfile. I can't explain why that flag causes issues with av.

After making the change in this PR against an older commit (1bb03ca0bb0f8be96658aad936061e928b6fd77f), I was still having issues when running `import av` that appear to be unique to ARM... but I don't have that issue against master.

@Shjba @oppermax @FlixFlix if you're able to test out this branch, I'd appreciate it!