### PR TITLE
Fix amixer bad volume argument

### DIFF
--- a/ap2/utils.py
+++ b/ap2/utils.py
@@ -221,7 +221,7 @@ def get_volume():
                 pct = 0
         vol = interpolate(pct, 0, 100, -30, 0)
     elif subsys == "Linux":
-        line_pct = subprocess.check_output(["amixer", "get", "PCM"]).splitlines()[-1]
+        line_pct = subprocess.check_output(["amixer", "get", "Master"]).splitlines()[-1]
         m = re.search(b"\[([0-9]+)%\]", line_pct)
         if m:
             pct = int(m.group(1))
@@ -255,7 +255,7 @@ def set_volume(vol):
     elif subsys == "Linux":
         pct = int(interpolate(vol, -30, 0, 45, 100))
 
-        subprocess.run(["amixer", "set", "PCM", f"{pct}%%"])
+        subprocess.run(["amixer", "set", "Master", f"{pct}%"])
     elif subsys == "Windows":
         volume_session = get_pycaw_volume_session()
         if volume_session:


### PR DESCRIPTION
Original implementation call  `amixer set PCM 50%%`, and get `amixer: Invalid command!` on Ubuntu 22.04.

Remove extra `%` and set volume of Master instead of PCM, this will make airplay2 works on any linux server.